### PR TITLE
Generalize selectedLigand

### DIFF
--- a/client/public/js/components/status.jsx
+++ b/client/public/js/components/status.jsx
@@ -1,5 +1,6 @@
-import { Map as IMap } from 'immutable';
+import { List as IList, Map as IMap } from 'immutable';
 import React from 'react';
+import { statusConstants } from 'molecular-design-applications-shared';
 import SelectionRecord from '../records/selection_record';
 import StatusAbout from './status_about';
 import StatusLigandSelection from './status_ligand_selection';
@@ -9,7 +10,6 @@ import StatusResults from './status_results';
 import WorkflowRecord from '../records/workflow_record';
 import ioUtils from '../utils/io_utils';
 import selectionConstants from '../constants/selection_constants';
-import { statusConstants } from 'molecular-design-applications-shared';
 
 require('../../css/status.scss');
 
@@ -107,7 +107,7 @@ function Status(props) {
           .fetchedValue;
 
         if (outputResults.output_values) {
-          resultValues = outputResults.output_values;
+          resultValues = new IList(outputResults.output_values);
         }
       }
 

--- a/client/public/js/components/status_results.jsx
+++ b/client/public/js/components/status_results.jsx
@@ -91,7 +91,7 @@ StatusResults.propTypes = {
   morph: React.PropTypes.number.isRequired,
   numberOfPdbs: React.PropTypes.number.isRequired,
   outputPdbUrl: React.PropTypes.string,
-  resultValues: React.PropTypes.instanceOf(Array),
+  resultValues: React.PropTypes.instanceOf(IList),
 };
 
 export default StatusResults;

--- a/client/public/js/components/view.jsx
+++ b/client/public/js/components/view.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { List as IList } from 'immutable';
 
 /*
 We use Autodesk Molecule Viewer to display and navigate molecular data. Autodesk Molecule Viewer is not released under an open source license. For more information about the Autodesk Molecule Viewer license please refer to: https://molviewer.com/molviewer/docs/Pre-Release_Product_Testing_Agreement.pdf.
@@ -91,7 +92,7 @@ class View extends React.Component {
         }
 
         addModelPromise.then(() => {
-          if (selectionStrings) {
+          if (selectionStrings && this.moleculeViewer) {
             this.moleculeViewer.clearSelection();
             selectionStrings.forEach(selectionString =>
               this.moleculeViewer.select(selectionString),
@@ -138,7 +139,7 @@ class View extends React.Component {
 }
 
 View.defaultProps = {
-  selectionStrings: [],
+  selectionStrings: new IList(),
   modelData: '',
   error: '',
   colorized: false,
@@ -149,7 +150,7 @@ View.propTypes = {
   error: React.PropTypes.string,
   loading: React.PropTypes.bool.isRequired,
   modelData: React.PropTypes.string,
-  selectionStrings: React.PropTypes.instanceOf(Array),
+  selectionStrings: React.PropTypes.instanceOf(IList),
 };
 
 export default View;

--- a/client/public/js/components/workflow.jsx
+++ b/client/public/js/components/workflow.jsx
@@ -43,9 +43,10 @@ function Workflow(props) {
   }
 
   let selectionStrings = null;
-  if (props.workflow.run.selectedLigand) {
+  const selectedLigand = ioUtils.getSelectedLigand(props.workflow.run.inputs);
+  if (selectedLigand) {
     selectionStrings = ioUtils.getLigandSelectionStrings(
-      props.workflow.run.inputs, props.workflow.run.selectedLigand,
+      props.workflow.run.inputs, selectedLigand,
     );
   }
 
@@ -79,7 +80,7 @@ function Workflow(props) {
         onClickColorize={props.onClickColorize}
         onChangeMorph={props.onChangeMorph}
         onSelectInputFile={props.onSelectInputFile}
-        selectedLigand={props.workflow.run.selectedLigand}
+        selectedLigand={selectedLigand}
         selection={props.selection}
         submitInputString={props.submitInputString}
         submitEmail={props.submitEmail}

--- a/client/public/js/components/workflow_steps.jsx
+++ b/client/public/js/components/workflow_steps.jsx
@@ -30,7 +30,7 @@ function WorkflowSteps(props) {
     statusConstants.COMPLETED : statusConstants.IDLE;
   let emailLast = true;
 
-  const ligandStatus = props.workflow.run.selectedLigand ?
+  const ligandStatus = ioUtils.getSelectedLigand(props.workflow.run.inputs) ?
     statusConstants.COMPLETED : statusConstants.IDLE;
   const ligandCompleted = loadCompleted && (!props.workflow.selectLigands ||
     ligandStatus === statusConstants.COMPLETED);

--- a/client/public/js/containers/workflow_root.jsx
+++ b/client/public/js/containers/workflow_root.jsx
@@ -34,15 +34,17 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    changeLigandSelection(ligandString) {
-      dispatch(changeLigandSelection(ligandString));
+    changeLigandSelection(inputs) {
+      return (ligand) => {
+        dispatch(changeLigandSelection(inputs, ligand));
+      };
     },
     clickAbout() {
       dispatch(clickAbout());
     },
-    clickRun(workflowId, email, inputs, selectedLigand, inputString) {
+    clickRun(workflowId, email, inputs, inputString) {
       return () => {
-        dispatch(clickRun(workflowId, email, inputs, selectedLigand, inputString));
+        dispatch(clickRun(workflowId, email, inputs, inputString));
       };
     },
     clickWorkflowNodeLigandSelection() {
@@ -99,12 +101,14 @@ function mergeProps(stateProps, dispatchProps) {
       stateProps.workflow.id,
       stateProps.workflow.run.email,
       stateProps.workflow.run.inputs,
-      stateProps.workflow.run.selectedLigand,
       stateProps.workflow.run.inputString,
     ),
     clickCancel: dispatchProps.clickCancel(stateProps.workflow.run.id),
     onSelectInputFile: dispatchProps.onSelectInputFile(stateProps.workflow.id),
     submitInputString: dispatchProps.submitInputString(stateProps.workflow.id),
+    changeLigandSelection: dispatchProps.changeLigandSelection(
+      stateProps.workflow.run.inputs,
+    ),
   });
 }
 

--- a/client/public/js/records/run_record.js
+++ b/client/public/js/records/run_record.js
@@ -13,7 +13,6 @@ const RunRecord = new Record({
   inputString: '',
   inputStringError: null,
   outputs: new IList(),
-  selectedLigand: '',
   status: statusConstants.IDLE,
 });
 

--- a/client/public/js/reducers/workflow.js
+++ b/client/public/js/reducers/workflow.js
@@ -1,10 +1,8 @@
 import { List as IList } from 'immutable';
 import { statusConstants } from 'molecular-design-applications-shared';
-import IoRecord from '../records/io_record';
 import RunRecord from '../records/run_record';
 import WorkflowRecord from '../records/workflow_record';
 import actionConstants from '../constants/action_constants';
-import ioUtils from '../utils/io_utils';
 
 const initialState = new WorkflowRecord();
 
@@ -69,7 +67,6 @@ function workflow(state = initialState, action) {
       return state.set('run', state.run.merge({
         inputs: action.inputs,
         outputs: action.outputs,
-        selectedLigand: action.selectedLigand,
       }));
 
     case actionConstants.CLICK_RUN:
@@ -101,21 +98,12 @@ function workflow(state = initialState, action) {
         inputs: [],
       }));
 
-    case actionConstants.INPUT_FILE_COMPLETE: {
-      let ligands = new IList();
-      const inputs = action.inputs ? action.inputs : new IList();
-
-      if (inputs.size) {
-        ligands = ioUtils.getLigandNames(inputs);
-      }
-
+    case actionConstants.INPUT_FILE_COMPLETE:
       return state.set('run', state.run.merge({
         fetchingData: false,
         inputFileError: action.error,
-        inputs,
-        selectedLigand: ligands.size === 1 ? ligands.get(0) : '',
+        inputs: action.inputs || new IList(),
       }));
-    }
 
     case actionConstants.SUBMIT_INPUT_STRING:
       return state.set('run', state.run.merge({
@@ -127,20 +115,10 @@ function workflow(state = initialState, action) {
       }));
 
     case actionConstants.PROCESSED_INPUT_STRING: {
-      let ligands = new IList();
-      const inputs = action.inputs ?
-        action.inputs.map(input => new IoRecord(input)) :
-        new IList();
-
-      if (inputs.size) {
-        ligands = ioUtils.getLigandNames(inputs);
-      }
-
       return state.set('run', state.run.merge({
         fetchingData: false,
         inputStringError: action.error,
-        inputs,
-        selectedLigand: ligands.size === 1 ? ligands.get(0) : '',
+        inputs: action.inputs || new IList(),
       }));
     }
 
@@ -168,7 +146,7 @@ function workflow(state = initialState, action) {
     case actionConstants.CHANGE_LIGAND_SELECTION:
       return state.set(
         'run',
-        state.run.set('selectedLigand', action.ligandString),
+        state.run.set('inputs', action.inputs),
       );
 
     default:

--- a/client/public/js/utils/api_utils.js
+++ b/client/public/js/utils/api_utils.js
@@ -121,7 +121,7 @@ const apiUtils = {
   /**
    * Fetch and parse the json file that is returned from step0 input processing
    * @param jsonUrl {String}
-   * @returns {Object}
+   * @returns {Promise}
    */
   getIoData(jsonUrl) {
     return axios.get(jsonUrl).then(res => res.data);

--- a/server/utils/seed_data.js
+++ b/server/utils/seed_data.js
@@ -1,5 +1,5 @@
 const workflows = [
- {
+  {
     id: '0',
     title: 'Calculate electronic vertical detachment energy',
     selectLigands: false,
@@ -51,4 +51,3 @@ const workflows = [
 ];
 
 module.exports = workflows;
-


### PR DESCRIPTION
This PR is a refactor that sets us up to move to a generic, dynamic step UI.  `selectedLigand` previously was duplicated state, stored in an inconvenient place in selection.json as given by the server, and also stored directly on the run.  This gets rid of the direct storage on the run so there is only one source of truth, and we can rely more on using server inputs for generic storage in the future.

Part of issue https://github.com/Autodesk/molecular-simulation-tools/issues/204