### PR TITLE
Fix MolViewer Bugs on Destruction

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
-    "tirrenu": "../molecule_viewer/tirrenu-1.3.2.tgz",
+    "tirrenu": "../molecule_viewer/tirrenu-1.3.3.tgz",
     "validator": "^6.2.0"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
-    "tirrenu": "../molecule_viewer/tirrenu-1.3.3.tgz",
+    "tirrenu": "../molecule_viewer/tirrenu-1.3.4.tgz",
     "validator": "^6.2.0"
   },
   "devDependencies": {

--- a/client/public/css/view.scss
+++ b/client/public/css/view.scss
@@ -39,3 +39,6 @@
 #guiviewer3d-toolbar {
   display: none !important;
 }
+#qrCode {
+  display: none;
+}

--- a/client/public/js/components/status.jsx
+++ b/client/public/js/components/status.jsx
@@ -96,7 +96,10 @@ function Status(props) {
           submitEmail={props.submitEmail}
         />
       );
-    } else if (props.selection.type === selectionConstants.WORKFLOW_NODE_RESULTS) {
+    } else if (
+      props.selection.type === selectionConstants.WORKFLOW_NODE_RESULTS &&
+      props.workflow.run.outputs.size
+    ) {
       const outputResultsIndex = ioUtils.getIndexByExtension(
         props.workflow.run.outputs, 'results.json',
       );

--- a/client/public/js/components/status_results.jsx
+++ b/client/public/js/components/status_results.jsx
@@ -1,4 +1,3 @@
-import { List as IList } from 'immutable';
 import React from 'react';
 import Button from './button';
 
@@ -82,7 +81,7 @@ class StatusResults extends React.Component {
 
 StatusResults.defaultProps = {
   outputPdbUrl: '',
-  resultValues: new IList(),
+  resultValues: [],
 };
 
 StatusResults.propTypes = {

--- a/client/public/js/components/view.jsx
+++ b/client/public/js/components/view.jsx
@@ -1,16 +1,7 @@
 import React from 'react';
-
-/*
-We use Autodesk Molecule Viewer to display and navigate molecular data. Autodesk Molecule Viewer is not released under an open source license. For more information about the Autodesk Molecule Viewer license please refer to: https://molviewer.com/molviewer/docs/Pre-Release_Product_Testing_Agreement.pdf.
-*/
-import $ADSKMOLVIEW from 'tirrenu';
-
+import MoleculeViewerWrapper from '../utils/molecule_viewer_wrapper';
 import loadImg from '../../img/loadAnim.gif';
-
-require('../../css/view.scss');
-
-const MOL_VIEW_INITIALIZED = 'viewerInitialized';
-const MOL_VIEW_MODEL_LOADED = 'Nano.ModelEndLoaded';
+import '../../css/view.scss';
 
 class View extends React.Component {
   componentDidMount() {
@@ -31,78 +22,30 @@ class View extends React.Component {
     );
   }
 
-  createMoleculeViewer() {
-    this.moleculeViewer = new $ADSKMOLVIEW(this.moleculeViewerContainer, {
-      headless: true,
-    });
-
-    return new Promise((resolve) => {
-      const molViewInitialized = () => {
-        if (this.moleculeViewer) {
-          this.moleculeViewer.mv.removeEventListener(
-            MOL_VIEW_INITIALIZED, molViewInitialized,
-          );
-        }
-        resolve();
-      };
-
-      this.moleculeViewer.mv.addEventListener(
-        MOL_VIEW_INITIALIZED, molViewInitialized,
-      );
-    });
-  }
-
-  addModelToMoleculeViewer(modelData) {
-    return new Promise((resolve) => {
-      const molViewModelLoaded = () => {
-        if (this.moleculeViewer) {
-          this.moleculeViewer.mv.removeEventListener(
-            MOL_VIEW_MODEL_LOADED, molViewModelLoaded,
-          );
-        }
-        resolve();
-      };
-
-      this.moleculeViewer.mv.addEventListener(
-        MOL_VIEW_MODEL_LOADED, molViewModelLoaded,
-      );
-      this.moleculeViewer.createMoleculeFromFile(modelData, 'pdb');
-    });
-  }
-
   renderMoleculeViewer(modelData, oldModelData, selectionStrings, loading) {
-    let createMoleculeViewerPromise = Promise.resolve();
-
     // Create or destroy the molviewer when needed
-    if ((loading || !modelData) && this.moleculeViewer) {
+    if ((loading || !modelData) && this.moleculeViewerW) {
       // TODO the molviewer api should provide a better way to destroy itself
-      document.querySelector('.adsk-viewing-viewer').remove();
-      this.moleculeViewer = undefined;
-    } else if (modelData && !this.moleculeViewer) {
-      createMoleculeViewerPromise = this.createMoleculeViewer();
+      this.moleculeViewerW.destroy();
+      this.moleculeViewerW = undefined;
+    } else if (modelData && !this.moleculeViewerW) {
+      this.moleculeViewerW = new MoleculeViewerWrapper(
+        this.moleculeViewerContainer,
+      );
     }
 
     // Update the model whenever it's different than last render
-    if (modelData && this.moleculeViewer) {
-      createMoleculeViewerPromise.then(() => {
-        let addModelPromise = Promise.resolve();
-        if (modelData !== oldModelData) {
-          addModelPromise = this.addModelToMoleculeViewer(modelData);
-        }
+    if (modelData && this.moleculeViewerW) {
+      if (modelData !== oldModelData) {
+        this.moleculeViewerW.addModel(modelData);
+      }
 
-        addModelPromise.then(() => {
-          if (selectionStrings) {
-            this.moleculeViewer.clearSelection();
-            selectionStrings.forEach(selectionString =>
-              this.moleculeViewer.select(selectionString),
-            );
-            this.moleculeViewer.focusOnSelection();
-          }
-        });
-      });
+      if (selectionStrings) {
+        this.moleculeViewerW.select(selectionStrings);
+      }
     }
 
-    // TODO colorized like: this.moleculeViewer.setColor('ribbon', 'blue', '1');
+    // TODO colorized like: moleculeViewer.setColor('ribbon', 'blue', '1');
   }
 
   render() {

--- a/client/public/js/reducers/selection.js
+++ b/client/public/js/reducers/selection.js
@@ -52,11 +52,22 @@ function selection(state = initialState, action) {
         type: selectionConstants.ABOUT,
       });
 
+    case actionConstants.FETCHED_WORKFLOW:
+      if (action.error) {
+        return state;
+      }
+      // Reset selection when loading a workflow
+      return state.merge({
+        id: null,
+        type: selectionConstants.WORKFLOW_NODE_LOAD,
+      });
+
     case actionConstants.FETCHED_RUN:
       if (action.error ||
         action.workflow.run.status !== statusConstants.COMPLETED) {
         return state;
       }
+      // Select results when loading a finished run
       return state.merge({
         id: null,
         type: selectionConstants.WORKFLOW_NODE_RESULTS,

--- a/client/public/js/utils/molecule_viewer_wrapper.js
+++ b/client/public/js/utils/molecule_viewer_wrapper.js
@@ -1,0 +1,91 @@
+/*
+We use Autodesk Molecule Viewer to display and navigate molecular data. Autodesk Molecule Viewer is not released under an open source license. For more information about the Autodesk Molecule Viewer license please refer to: https://molviewer.com/molviewer/docs/Pre-Release_Product_Testing_Agreement.pdf.
+*/
+import $ADSKMOLVIEW from 'tirrenu';
+
+const MOL_VIEW_INITIALIZED = 'viewerInitialized';
+const MOL_VIEW_MODEL_LOADED = 'Nano.ModelEndLoaded';
+
+class MoleculeViewerWrapper {
+  container = null
+  moleculeViewer = null
+  createPromise = null
+  addModelPromise = Promise.resolve()
+
+  constructor(container) {
+    this.container = container;
+
+    // Create the moleculeViewer
+    const moleculeViewer = new $ADSKMOLVIEW(container, {
+      headless: true,
+    });
+    this.moleculeViewer = moleculeViewer;
+
+    // Can't do anything with moleculeViewer until this event fires
+    this.createPromise = new Promise((resolve) => {
+      const molViewInitialized = () => {
+        if (moleculeViewer) {
+          moleculeViewer.mv.removeEventListener(
+            MOL_VIEW_INITIALIZED, molViewInitialized,
+          );
+        }
+        resolve();
+      };
+
+      this.moleculeViewer.mv.addEventListener(
+        MOL_VIEW_INITIALIZED, molViewInitialized,
+      );
+    });
+  }
+
+  /**
+   * Destroy the viewer in the UI
+   */
+  destroy() {
+    this.container.querySelector('.adsk-viewing-viewer').remove();
+  }
+
+  /**
+   * Add the given model to the viewer
+   * @param {String} modelData
+   */
+  addModel(modelData) {
+    const lastAddModelPromise = this.addModelPromise || Promise.resolve();
+
+    // Can't do anything after adding a model until an event fires
+    this.addModelPromise = new Promise((resolve) => {
+      // Must wait for create and any previous addModel
+      Promise.all([this.createPromise, lastAddModelPromise]).then(() => {
+        const molViewModelLoaded = () => {
+          if (this.moleculeViewer) {
+            this.moleculeViewer.mv.removeEventListener(
+              MOL_VIEW_MODEL_LOADED, molViewModelLoaded,
+            );
+          }
+          resolve();
+        };
+
+        this.moleculeViewer.mv.addEventListener(
+          MOL_VIEW_MODEL_LOADED, molViewModelLoaded,
+        );
+        this.moleculeViewer.createMoleculeFromFile(modelData, 'pdb');
+      });
+    });
+  }
+
+  /**
+   * Select and focus on given selectionStrings
+   * @param {Array} selectionStrings
+   */
+  select(selectionStrings) {
+    Promise.all([this.createPromise, this.addModelPromise]).then(() => {
+      this.moleculeViewer.clearSelection();
+      selectionStrings.forEach(selectionString =>
+        this.moleculeViewer.select(selectionString),
+      );
+      this.moleculeViewer.focusOnSelection();
+    });
+  }
+}
+
+export default MoleculeViewerWrapper;

--- a/client/public/js/utils/molecule_viewer_wrapper.js
+++ b/client/public/js/utils/molecule_viewer_wrapper.js
@@ -68,7 +68,7 @@ class MoleculeViewerWrapper {
         this.moleculeViewer.mv.addEventListener(
           MOL_VIEW_MODEL_LOADED, molViewModelLoaded,
         );
-        this.moleculeViewer.createMoleculeFromFile(modelData, 'pdb');
+        this.moleculeViewer.createMoleculeFromData(modelData, 'pdb', true);
       });
     });
   }


### PR DESCRIPTION
I was seeing lots of errors popping up in corner cases for the molviewer: switching morph frames quickly, and navigating onto and off of pages with the molviewer.  This PR cleans up the sketchiness of that code by wrapping the asynchronous complexity of the molviewer into a wrapper class.