### PR TITLE
Reroute /test/all -> /test (requested by devops)

### DIFF
--- a/server/routes/test.js
+++ b/server/routes/test.js
@@ -45,17 +45,28 @@ router.get('/workflow1', (req, res) => {
 });
 
 router.get('/all', (req, res) => {
-  testUtils.runAllTests()
+  /**
+   * Until /workflow0 works reliably every time (it sometimes fails)
+   * this route is just replicating /test
+   */
+  testUtils.runTestCCC()
     .then((result) => {
-      if (result.success) {
-        res.send(result);
-      } else {
-        res.status(500).send(result);
-      }
+      res.send({success:true, result});
     })
     .catch((err) => {
       res.status(500).send(JSON.stringify({success:false, error:err}));
     });
+  // testUtils.runAllTests()
+  //   .then((result) => {
+  //     if (result.success) {
+  //       res.send(result);
+  //     } else {
+  //       res.status(500).send(result);
+  //     }
+  //   })
+  //   .catch((err) => {
+  //     res.status(500).send(JSON.stringify({success:false, error:err}));
+  //   });
 });
 
 module.exports = router;


### PR DESCRIPTION
Reroute /test/all -> /test until /test/workflow0 stops occasionally failing

Slack discussion:

@virshua @amagod which verification endpoint should work for testing a simple workflow ? I run this test during deployment.

I used to use `/test/all`   then a month ago we switched to `/test/workflow0`

Now, however `/test/workflow0` fails (404)

Any idea why this fails? Should I go back to using `/test/all` ?

— UPDATE: *sometimes* `/test/workflow0` fails. Should I still use this endpoint ? (edited)

7 replies
Dion Amago [27 minutes ago] 
@jonesp Following up on my answer below: @virshua I remember the workflow0 (vde) sometimes having a python crash. This doesn't really work as a verification test, so I propose just using the `/test` which *only* checks CCC connectivity until we can reliably run `workflow0`. This is not ideal, but until the issue of the vde workflow sometimes failing is resolved, I see it as the least worst solution.

Peter Jones (Slack Admin) [25 minutes ago] 
I’m okay with this idea. One request though - let’s make a different route (e.g. `/test/all`) so that the rest endpoint for build deployment verification can be different than the monitor endpoint. For now they can do the same thing internally

Dion Amago [21 minutes ago] 
That exists already, and does what you want. `/test` just checks CCC, while `/test/all` runs the two workflows.

Dion Amago [21 minutes ago] 
But of course, `/test/all` will sometimes fail as described above.

Peter Jones (Slack Admin) [5 minutes ago] 
I’m advocating to change, temporarily, to have `/test/all` do the same as `/test` until we figure out why the current `/test/all` fails sometimes - make sense ?

Dion Amago [4 minutes ago] 
Ah got it. I'll make that change now.